### PR TITLE
Resolve Django Debug Toolbar v2 compatibility

### DIFF
--- a/debug_toolbar_sqlalchemy/panel.py
+++ b/debug_toolbar_sqlalchemy/panel.py
@@ -14,9 +14,6 @@ class SqlAlchemyDebugPanel(Panel):
         self.tracker = OperationTracker()
         self.tracker.register()
 
-    def process_request(self, request):
-        pass
-
     def nav_title(self):
         return _('SQLAlchemy')
 


### PR DESCRIPTION
Hello.

I found out that new version of **Django Debug Toolbar v2**, has changed to new middleware style which was introduced in **Django v2** and now with version **Django v3** the old style was deprecated and **Django Debug Toolbar** was forced to adapt and therefore this add-on has stopped working.

So, I found out, that the solution is, removing ``process_request`` override in ``panel.py``.

Looking forward to resolution of this little problem as I do enjoy using your add-on.

Edit: [Django Debug Toolbar changelog](https://django-debug-toolbar.readthedocs.io/en/latest/changes.html)