### PR TITLE
Update for Django 4.0.0

### DIFF
--- a/debug_toolbar_sqlalchemy/panel.py
+++ b/debug_toolbar_sqlalchemy/panel.py
@@ -1,7 +1,7 @@
 from debug_toolbar.panels import Panel
 from debug_toolbar_sqlalchemy.operation_tracker import OperationTracker
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.template.loader import render_to_string
 
 


### PR DESCRIPTION
In Django 4.0.0, the `ugettext` alias for `gettext` was [removed](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0) after being [deprecated in Django 3.0](https://docs.djangoproject.com/en/4.0/releases/3.0/#features-deprecated-in-3-0).  This PR updates the code to use `gettext` instead of `ugettext`.